### PR TITLE
Fix: Positive total target amount file naming convention

### DIFF
--- a/dev/TODOs
+++ b/dev/TODOs
@@ -1,3 +1,5 @@
+# TODO: - DOUBLE CHECK IF IT IS ONLY EFTs that follow the () naming convention for positive values, if not then remove that condition in the else
+
 WIP - # TODO: dynamically create subdirs for YYYY and NUM-MONTH for each directory in DTN Reports --> use company_id to company subdir root path mapping
 
 # TODO: Update with Windows filepaths (staging and prod)

--- a/utils/extraction_handler.py
+++ b/utils/extraction_handler.py
@@ -33,7 +33,6 @@ def extract_info_from_text(current_page_text, regex_pattern):
         print(f'No matches for regex: {regex_pattern} in\n {current_page_text}')
         regex_num = None
 
-    # TODO: If - in front or behind, then turn (total_amount) in filename, else today-total_amount in file_name
     # Extract total_target_value
     total_amount_matches = re.findall(r'-?[\d,]+\.\d+-?', current_page_text)
     # print(f'\nGetting total_amount_matches: {total_amount_matches}\n')

--- a/utils/pdf_handler.py
+++ b/utils/pdf_handler.py
@@ -74,9 +74,14 @@ def create_and_save_pdf(pages, new_file_name, destination_dir):
         return False  # Return False if an error occurred
 
 def get_new_file_name(regex_num, today, total_target_amt):
+    # TODO: double check if it is only EFTs that follow this convention
     # File naming convention for total_target_amt preceding/succeeding with a hyphen indicative of a balance owed
     if re.match(r'EFT-\s*\d+', regex_num) and re.match(r'-?[\d,]+\.\d+-?', total_target_amt):
-        new_file_name = f'{regex_num}-{today}-({total_target_amt}).pdf'
+        if "-" in total_target_amt:  # Checks if "-" exists anywhere in total_target_amt
+            total_target_amt = total_target_amt.replace("-", "")  # Removes "-"
+            new_file_name = f'{regex_num}-{today}-({total_target_amt}).pdf'
+        else:  # No "-" in total_target_amt
+            new_file_name = f'{regex_num}-{today}-{total_target_amt}.pdf'
 
     # File naming convention for chargebacks/retrievals
     # @dev: regex_num is included due to edge case of identical filenames overwriting
@@ -84,7 +89,7 @@ def get_new_file_name(regex_num, today, total_target_amt):
     elif (re.match(r'CBK-\s*\d+', regex_num) or re.match(r'RTV-\s*\d+', regex_num)):
         new_file_name = f'{regex_num}-{today}-CHARGEBACK REQUEST.pdf'
 
-    # File naming convention for all other files (CCM, CMB, non negative total amount values)
+    # File naming convention for all other files (CCM, CMB, positive ETF `total_amount` values)
     else:
         new_file_name = f'{regex_num}-{today}-{total_target_amt}.pdf'
     # print(f'new_file_name: {new_file_name}')


### PR DESCRIPTION
Conditional checks for `-` in filename for only EFT files to determine naming  convention. 